### PR TITLE
fix: multi Root Folder support

### DIFF
--- a/src/plex_nfs_watchdog/modules/plex/plex_agent.py
+++ b/src/plex_nfs_watchdog/modules/plex/plex_agent.py
@@ -154,8 +154,9 @@ class PlexAgent:
         :return:
         """
         for section in self.__server.library.sections():
-            remote_path: str = section.locations[0]
-            self.__internal_paths[Path(remote_path).name] = (section.title, remote_path)
+            for location in section.locations:
+                remote_path: str = location
+                self.__internal_paths[Path(remote_path).name] = (section.title, remote_path)
 
     def is_plex_section(self, folder_name: str) -> bool:
         """
@@ -194,7 +195,7 @@ class PlexAgent:
                 logging.warning(f"Plex section {section_title} is already refreshing, skipping...")
             return
         scan_path: Path = Path(f"{section_path}/{item}")
-        logging.info(f"Requesting Plex to scan remote path {str(scan_path)}")
+        logging.info(f"Requesting Plex to scan remote path {str(item)}")
         if shared.user_input.dry_run:
             logging.info(f"Skipping Plex scan due to dry-run")
         else:
@@ -210,7 +211,7 @@ class PlexAgent:
         for given_path in paths:
             logging.info(f"Analyzing {given_path}")
             if given_path.name in self.__internal_paths.keys():
-                scan_sections.add((given_path.name, ""))
+                scan_sections.add((given_path.name, given_path))
             else:
                 section_child: Path | None = self.__find_section_child_of(given_path)
                 if section_child is None:


### PR DESCRIPTION
Enable support for multiple Root Folders in a single Library.

Update logging to reflect multiple Root Folders.

Please see the __contributing guidelines__ for how to create and submit a PR.

### Description

The purpose of the PR is to properly treat Plex library sections as a list. This code now iterates through the list of library sections, adding each section as a remote_path to monitor.

### References

[Multiple media folders for one library does not work](https://github.com/LightDestory/PlexNFSWatchdog/issues/4)

### Checklist

- [x] If necessary, I have added documentation for new/changed functionality in this PR
- [x] If present, all active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if the target is not `master`
